### PR TITLE
ユーザー情報の登録APIの実装

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -107,15 +107,17 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - email_address
+                - password
               properties:
-                name:
+                email_address:
                   type: string
-                  description: "ユーザー名"
-                email:
-                  type: string
+                  example: example@example.com
                   description: "ユーザーのメールアドレス"
                 password:
                   type: string
+                  example: fasdfasdf
                   description: "ユーザーのパスワード"
       responses:
         "201":
@@ -125,12 +127,9 @@ paths:
               schema:
                 type: object
                 properties:
-                  userId:
+                  message:
                     type: string
-                    description: "ユーザーID"
-                  token:
-                    type: string
-                    description: "認証トークン"
+                    example: ユーザーを登録しました
         "400":
           description: Invalid input
           content:

--- a/backend/hackathon_backend/serializer.py
+++ b/backend/hackathon_backend/serializer.py
@@ -1,7 +1,17 @@
 from rest_framework import serializers
-from .models import Habits
+from .models import Habits, Users
+from django.contrib.auth.hashers import make_password
 
 class HabitsSerializer(serializers.ModelSerializer):
     class Meta:
         model = Habits
         fields = ('habit_name', 'judge_method', 'enabled_notification', 'judge_time', 'user_id', 'payment_money', 'payment_method')
+
+class UsersSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Users
+        fields = ('email_address', 'password')
+        extra_kwargs = {'password': {'write_only': True}}
+        
+    def validate_password(self, value):
+        return make_password(value)

--- a/backend/hackathon_backend/urls.py
+++ b/backend/hackathon_backend/urls.py
@@ -5,5 +5,6 @@ from . import views
 
 urlpatterns = [
     path('habits', views.HabitViews.as_view()),
-    path('habits/<int:id>', views.PutDeleteHabitView.as_view())
+    path('habits/<int:id>', views.PutDeleteHabitView.as_view()),
+    path('user', views.UserView.as_view())
 ]

--- a/backend/hackathon_backend/views.py
+++ b/backend/hackathon_backend/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 from rest_framework import views, status
-from .serializer import HabitsSerializer
+from .serializer import HabitsSerializer, UsersSerializer
 from rest_framework.response import Response
 from .models import Habits, Users
 
@@ -52,5 +52,12 @@ class PutDeleteHabitView(views.APIView):
 
         habit.delete()
         return Response({"message": "習慣化項目の削除に成功しました"}, status=status.HTTP_200_OK)
+    
+class UserView(views.APIView):
+    def post(self, request, *args, **kwargs):
+        serializer = UsersSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response({"message": "ユーザーを登録しました"}, status=status.HTTP_201_CREATED)
 
 # Create your views here.


### PR DESCRIPTION
## 概要
ユーザー情報の登録APIを実装しました。

## 実装内容

- [ユーザー情報追加APIのAPI仕様書修正](https://github.com/Yoshida-koshi/yumemi-pg-hackathon-team1/commit/889a41d75c0ec89a91402d5185c5f48555ff53e3)
- [ユーザー情報の追加APIを実装](https://github.com/Yoshida-koshi/yumemi-pg-hackathon-team1/commit/0ade838555845b57677ce152f4ef381c2744747e)
